### PR TITLE
Amend Makefile.PL and generate META files

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,8 +1,10 @@
-MANIFEST
 Changes
+lib/HTML/Scrubber/StripScripts.pm
 Makefile.PL
+MANIFEST			This list of files
+META.json
+META.yml
 README
-StripScripts.pm
 t/10default.t
 t/20href.t
 t/30src.t

--- a/META.json
+++ b/META.json
@@ -1,0 +1,42 @@
+{
+   "abstract" : "Strip scripting from HTML",
+   "author" : [
+      "Nick Cleaton <nick@cleaton.net>"
+   ],
+   "dynamic_config" : 0,
+   "generated_by" : "ExtUtils::MakeMaker version 6.66, CPAN::Meta::Converter version 2.120921",
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "HTML-Scrubber-StripScripts",
+   "no_index" : {
+      "directory" : [
+         "t",
+         "inc"
+      ]
+   },
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "ExtUtils::MakeMaker" : "0"
+         }
+      },
+      "configure" : {
+         "requires" : {
+            "ExtUtils::MakeMaker" : "0"
+         }
+      },
+      "runtime" : {
+         "requires" : {
+            "HTML::Scrubber" : "0.11",
+            "Test::More" : "0"
+         }
+      }
+   },
+   "release_status" : "stable",
+   "version" : "0.03"
+}

--- a/META.yml
+++ b/META.yml
@@ -1,0 +1,23 @@
+---
+abstract: 'Strip scripting from HTML'
+author:
+  - 'Nick Cleaton <nick@cleaton.net>'
+build_requires:
+  ExtUtils::MakeMaker: 0
+configure_requires:
+  ExtUtils::MakeMaker: 0
+dynamic_config: 0
+generated_by: 'ExtUtils::MakeMaker version 6.66, CPAN::Meta::Converter version 2.120921'
+license: perl
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: 1.4
+name: HTML-Scrubber-StripScripts
+no_index:
+  directory:
+    - t
+    - inc
+requires:
+  HTML::Scrubber: 0.11
+  Test::More: 0
+version: 0.03

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,11 +1,14 @@
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-    'NAME'         => 'HTML::Scrubber::StripScripts',
-    'VERSION_FROM' => 'StripScripts.pm',
-    'PREREQ_PM'    => {
-                        'Test::More'     => 0,
-                        'HTML::Scrubber' => 0.03,
-                      },
+    'NAME'          => 'HTML::Scrubber::StripScripts',
+    'AUTHOR'        => 'Nick Cleaton <nick@cleaton.net>',
+    'VERSION_FROM'  => 'lib/HTML/Scrubber/StripScripts.pm',
+    'ABSTRACT_FROM' => 'lib/HTML/Scrubber/StripScripts.pm',
+    'PREREQ_PM'     => {
+                           'Test::More'     => 0,
+                           'HTML::Scrubber' => 0.11,
+                       },
+    'LICENSE'       => 'perl',
+    'EXE_FILES'     => [],
 );
-

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 NAME
-    HTML::Scrubber::StripScripts - strip scripting from HTML
+    HTML::Scrubber::StripScripts - Strip scripting from HTML
 
 SYNOPSIS
        use HTML::Scrubber::StripScripts;

--- a/lib/HTML/Scrubber/StripScripts.pm
+++ b/lib/HTML/Scrubber/StripScripts.pm
@@ -2,11 +2,11 @@ package HTML::Scrubber::StripScripts;
 use strict;
 
 use vars qw($VERSION);
-$VERSION = '0.02';
+$VERSION = '0.03';
 
 =head1 NAME
 
-HTML::Scrubber::StripScripts - strip scripting from HTML
+HTML::Scrubber::StripScripts - Strip scripting from HTML
 
 =head1 SYNOPSIS
 
@@ -255,7 +255,7 @@ sub new {
                         'vspace' => $re{'size'},
                         'align'  => $re{'word'},
                       },
-      ( $cfg{Whole_document} ? 
+      ( $cfg{Whole_document} ?
         ( 'body'  => { 'bgcolor'    => $re{'color'},
                         @background,
                         'link'       => $re{'color'},
@@ -321,4 +321,3 @@ under the same terms as Perl itself.
 =cut
 
 1;
-


### PR DESCRIPTION
**Problem**

CPAN release of _HTML::Scrubber::StripScripts_ does not include `META.yml` or `META.json` files which leads to problems with tools, that expect them. In my case, _fpm_ fails to create a package.

**Changes**

I have tweaked and amended `Makefile.PL` and used it to generate `META.yml` and `META.json` files, which are now included in version control.

Also:
- `MANIFEST` is regenerated,
- `StripScripts.pm` is relocated to comply with namespace recommendations, and
- version number is increased

**Conclusion**

Please, review, merge, and if at all possible, release a new version of _HTML::Scrubber::StripScripts_ in CPAN.
